### PR TITLE
Reveal solc command stderr output

### DIFF
--- a/tools/create-genesis/src/solc.rs
+++ b/tools/create-genesis/src/solc.rs
@@ -29,6 +29,12 @@ impl Solc {
             .arg("abi,bin,userdoc,hashes,devdoc")
             .output()
             .expect("solc command fail to execute");
+
+        if !output.status.success() {
+            let msg = String::from_utf8(output.stderr).unwrap_or_else(|_| "unknown".to_owned());
+            panic!("solc command exeuction error: {}", msg);
+        }
+
         let output = String::from_utf8(output.stdout).unwrap();
         let compiled = json::parse(&output).unwrap();
         let index = [&file_path, ":", contract_name].concat();


### PR DESCRIPTION
# Pull Request Template

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
- All new codes require tests to ensure against regressions.

## Templates

### Description of the Change

This change improves `solc` command failure diagnosis by check command output status and present the stderr message when it's available.

### Alternate Design
### Benefits
### Possible Drawbacks
### Verification Process
Make arbitrary syntax error in "Admin.sol" contract, or just use a nightly build version of `solc` (which  will not accept `pragma solidity 0.4.24` directive by design, see https://github.com/ethereum/solidity/issues/4170), then use `cita bebop create` to initialize blockchain, the error message will be reported like this:

```
thread 'main' panicked at 'solc command exeuction error: Warning: This is a pre-release compiler version, please do not use it in production.
/Users/bsdelf/project/repo/cita/target/data/cita/test-chain/template/contracts/src/common/Admin.sol:1:1: Error: Expected pragma, import directive or contract/interface/library definition.
ragma solidity 0.4.24;
^---^
```

```
thread 'main' panicked at 'solc command exeuction error: /Users/bsdelf/project/repo/cita/target/data/cita/test-chain/template/contracts/src/common/Admin.sol:1:1: Error: Source file requires different compiler version (current compiler is 0.5.12+commit.7709ece9.Darwin.appleclang - note that nightly builds are considered to be strictly less than the released version
pragma solidity 0.4.24;
^---------------------^
```

Without this patch, standard output error message won't show up:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UnexpectedEndOfJson', src/libcore/result.rs:1189:5
```

### Applicable Issues
